### PR TITLE
Move `quickcheck` to be a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,12 @@ repository = "https://github.com/panicbit/quickcheck_derive"
 version = "0.1.3"
 
 [dependencies]
-quickcheck = "0.4.1"
-syn = "0.14"
 proc-macro2 = "0.4"
+syn = "0.14"
 synstructure = "0.9"
+
+[dev-dependencies]
+quickcheck = "0.4.1"
 
 [lib]
 proc_macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
+extern crate proc_macro2;
+#[cfg(test)]
 extern crate quickcheck;
 #[macro_use]
 extern crate syn;
 #[macro_use]
 extern crate synstructure;
-extern crate proc_macro2;
 
 use proc_macro2::TokenStream;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro2;
 #[cfg(test)]
 extern crate quickcheck;
-#[macro_use]
+#[cfg_attr(test, macro_use)]
 extern crate syn;
 #[macro_use]
 extern crate synstructure;


### PR DESCRIPTION
`quickcheck` is only used for tests, so this commit improves compilation time.